### PR TITLE
style: adjust pods directory search spacing

### DIFF
--- a/src/components/AllEntitiesView.tsx
+++ b/src/components/AllEntitiesView.tsx
@@ -135,8 +135,8 @@ export function AllEntitiesView({
     <div className="flex justify-between items-center mb-3">
       <h3 className="text-sm font-medium">{listHeading}</h3>
       {handleAdd && (
-        <Button onClick={() => handleAdd()} size="sm" className="h-7 text-xs">
-          <Plus className="h-3 w-3 mr-1" />
+        <Button onClick={() => handleAdd()} className="h-9 px-4 text-sm font-medium">
+          <Plus className="h-4 w-4 mr-2" />
           {addButtonLabel}
         </Button>
       )}
@@ -439,7 +439,7 @@ export function AllEntitiesView({
                 placeholder={searchPlaceholder}
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-9 h-8"
+                className="pl-10 h-8"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- increase the left padding on the directory search input so the caret no longer overlaps the icon
- enlarge the Add button in the directory header to feel more intentional and tappable

## Testing
- npm run build *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d32854275c8320a69aa97f76370b19