### PR TITLE
Add progressive plan override panel for hydrated data

### DIFF
--- a/server/seeds/json/_meta.json
+++ b/server/seeds/json/_meta.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "exportedAt": "2025-09-24T02:14:09.257Z",
+  "exportedAt": "2025-09-24T12:36:50.415Z",
   "tables": [
     "organizations",
     "functions",

--- a/src/components/KRCard.tsx
+++ b/src/components/KRCard.tsx
@@ -11,6 +11,14 @@ import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Slider } from "./ui/slider";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { PlanOverridePanel } from "./PlanOverridePanel";
+import {
   Calendar,
   Target,
   TrendingUp,
@@ -18,6 +26,7 @@ import {
   Save,
   X,
   Trash2,
+  CalendarRange,
 } from "lucide-react";
 
 interface KRCardProps {
@@ -27,6 +36,8 @@ interface KRCardProps {
   progress: number;
   target: string;
   current: string;
+  baseline: string;
+  unit: string;
   deadline: string;
   owner: string;
   team: string;
@@ -62,6 +73,8 @@ export function KRCard({
   progress,
   target,
   current,
+  baseline,
+  unit,
   deadline,
   owner,
   team,
@@ -72,6 +85,7 @@ export function KRCard({
   const [isEditing, setIsEditing] = useState(false);
   const [editProgress, setEditProgress] = useState(progress);
   const [editCurrent, setEditCurrent] = useState(current);
+  const [planDialogOpen, setPlanDialogOpen] = useState(false);
 
   // Ensure status is valid, fallback to 'not-started' if invalid
   const validStatus = statusConfig[status] ? status : 'not-started';
@@ -107,154 +121,180 @@ export function KRCard({
     setIsEditing(false);
   };
   return (
-    <Card className="w-full">
-      <CardHeader className="pb-3">
-        <div className="flex items-start justify-between">
-          <div className="space-y-1 flex-1">
-            <CardTitle className="line-clamp-2">
-              {title}
-            </CardTitle>
-            <p className="text-muted-foreground line-clamp-2">
-              {description}
-            </p>
-          </div>
-          <div className="flex items-center gap-2 ml-2">
-            <Badge
-              variant="secondary"
-              className={`${statusConfig[validStatus].color} text-white border-0`}
-            >
-              {statusConfig[validStatus].label}
-            </Badge>
-            {onUpdate && !isEditing && (
+    <>
+      <Card className="w-full">
+        <CardHeader className="pb-3">
+          <div className="flex items-start justify-between">
+            <div className="space-y-1 flex-1">
+              <CardTitle className="line-clamp-2">
+                {title}
+              </CardTitle>
+              <p className="text-muted-foreground line-clamp-2">
+                {description}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 ml-2">
+              <Badge
+                variant="secondary"
+                className={`${statusConfig[validStatus].color} text-white border-0`}
+              >
+                {statusConfig[validStatus].label}
+              </Badge>
               <Button
                 size="sm"
                 variant="ghost"
-                onClick={() => setIsEditing(true)}
+                onClick={() => setPlanDialogOpen(true)}
                 className="h-6 w-6 p-0"
-                aria-label="Edit key result"
+                aria-label="Review plan values"
               >
-                <Edit2 className="h-3 w-3" />
+                <CalendarRange className="h-3 w-3" />
               </Button>
-            )}
-            {onDelete && (
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => onDelete(id)}
-                className="h-6 w-6 p-0 text-destructive"
-                aria-label="Delete key result"
-              >
-                <Trash2 className="h-3 w-3" />
-              </Button>
-            )}
+              {onUpdate && !isEditing && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setIsEditing(true)}
+                  className="h-6 w-6 p-0"
+                  aria-label="Edit key result"
+                >
+                  <Edit2 className="h-3 w-3" />
+                </Button>
+              )}
+              {onDelete && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onDelete(id)}
+                  className="h-6 w-6 p-0 text-destructive"
+                  aria-label="Delete key result"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
           </div>
-        </div>
-      </CardHeader>
+        </CardHeader>
 
-      <CardContent className="space-y-4">
-        {isEditing ? (
-          <>
-            <div className="space-y-3">
+        <CardContent className="space-y-4">
+          {isEditing ? (
+            <>
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="flex items-center gap-2">
+                      <Target className="h-4 w-4 text-muted-foreground" />
+                      Progress
+                    </span>
+                    <span className="font-medium">
+                      {editProgress}%
+                    </span>
+                  </div>
+                  <Slider
+                    value={[editProgress]}
+                    onValueChange={(value) =>
+                      setEditProgress(value[0])
+                    }
+                    max={100}
+                    step={1}
+                    className="w-full"
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-4 text-sm">
+                  <div className="space-y-1">
+                    <p className="text-muted-foreground">
+                      Current
+                    </p>
+                    <Input
+                      value={editCurrent}
+                      onChange={(e) =>
+                        setEditCurrent(e.target.value)
+                      }
+                      placeholder="Current value"
+                      className="h-8"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-muted-foreground">
+                      Target
+                    </p>
+                    <p className="font-medium py-2">{target}</p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2 pt-2">
+                  <Button
+                    size="sm"
+                    onClick={handleSave}
+                    className="flex-1"
+                  >
+                    <Save className="h-3 w-3 mr-1" />
+                    Save
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleCancel}
+                    className="flex-1"
+                  >
+                    <X className="h-3 w-3 mr-1" />
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <span className="flex items-center gap-2">
                     <Target className="h-4 w-4 text-muted-foreground" />
                     Progress
                   </span>
-                  <span className="font-medium">
-                    {editProgress}%
-                  </span>
+                  <span className="font-medium">{progress}%</span>
                 </div>
-                <Slider
-                  value={[editProgress]}
-                  onValueChange={(value) =>
-                    setEditProgress(value[0])
-                  }
-                  max={100}
-                  step={1}
-                  className="w-full"
-                />
+                <Progress value={progress} className="h-2" />
               </div>
 
               <div className="grid grid-cols-2 gap-4 text-sm">
                 <div className="space-y-1">
-                  <p className="text-muted-foreground">
-                    Current
-                  </p>
-                  <Input
-                    value={editCurrent}
-                    onChange={(e) =>
-                      setEditCurrent(e.target.value)
-                    }
-                    placeholder="Current value"
-                    className="h-8"
-                  />
+                  <p className="text-muted-foreground">Current</p>
+                  <p className="font-medium">{current}</p>
                 </div>
                 <div className="space-y-1">
-                  <p className="text-muted-foreground">
-                    Target
-                  </p>
-                  <p className="font-medium py-2">{target}</p>
+                  <p className="text-muted-foreground">Target</p>
+                  <p className="font-medium">{target}</p>
                 </div>
               </div>
+            </>
+          )}
 
-              <div className="flex items-center gap-2 pt-2">
-                <Button
-                  size="sm"
-                  onClick={handleSave}
-                  className="flex-1"
-                >
-                  <Save className="h-3 w-3 mr-1" />
-                  Save
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={handleCancel}
-                  className="flex-1"
-                >
-                  <X className="h-3 w-3 mr-1" />
-                  Cancel
-                </Button>
-              </div>
-            </div>
-          </>
-        ) : (
-          <>
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="flex items-center gap-2">
-                  <Target className="h-4 w-4 text-muted-foreground" />
-                  Progress
-                </span>
-                <span className="font-medium">{progress}%</span>
-              </div>
-              <Progress value={progress} className="h-2" />
-            </div>
+          <div className="flex items-center justify-between text-sm text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <Calendar className="h-3 w-3" />
+              Due {deadline}
+            </span>
+            <span>
+              {owner} • {team}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
 
-            <div className="grid grid-cols-2 gap-4 text-sm">
-              <div className="space-y-1">
-                <p className="text-muted-foreground">Current</p>
-                <p className="font-medium">{current}</p>
-              </div>
-              <div className="space-y-1">
-                <p className="text-muted-foreground">Target</p>
-                <p className="font-medium">{target}</p>
-              </div>
-            </div>
-          </>
-        )}
-
-        <div className="flex items-center justify-between text-sm text-muted-foreground">
-          <span className="flex items-center gap-1">
-            <Calendar className="h-3 w-3" />
-            Due {deadline}
-          </span>
-          <span>
-            {owner} • {team}
-          </span>
-        </div>
-      </CardContent>
-    </Card>
+      <Dialog open={planDialogOpen} onOpenChange={setPlanDialogOpen}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Plan overview</DialogTitle>
+            <DialogDescription>
+              Review hydrated weekly plan values and optionally override them for this key result.
+            </DialogDescription>
+          </DialogHeader>
+          <PlanOverridePanel
+            kr={{ id, title, baseline, target, unit }}
+            onDone={() => setPlanDialogOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/components/KRDetailDialog.tsx
+++ b/src/components/KRDetailDialog.tsx
@@ -10,6 +10,7 @@ import { Badge } from "./ui/badge";
 import { Progress } from "./ui/progress";
 import { Separator } from "./ui/separator";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { PlanOverridePanel } from "./PlanOverridePanel";
 import { 
   Save, 
   X, 
@@ -26,9 +27,10 @@ interface KRDetailDialogProps {
   onClose: () => void;
   onUpdate: (id: string, updates: Partial<KR>) => void;
   onAddWeeklyActual: (krId: string, weeklyActual: Omit<WeeklyActual, 'id' | 'krId'>) => void;
+  weeks?: string[];
 }
 
-export function KRDetailDialog({ kr, isOpen, onClose, onUpdate, onAddWeeklyActual }: KRDetailDialogProps) {
+export function KRDetailDialog({ kr, isOpen, onClose, onUpdate, onAddWeeklyActual, weeks }: KRDetailDialogProps) {
   const [editData, setEditData] = useState({
     current: '',
     progress: 0,
@@ -249,6 +251,12 @@ export function KRDetailDialog({ kr, isOpen, onClose, onUpdate, onAddWeeklyActua
 
           {/* Weekly Actuals Section */}
           <div className="space-y-4">
+            <Card>
+              <CardContent className="pt-6">
+                <PlanOverridePanel kr={kr} weeks={weeks} condensed />
+              </CardContent>
+            </Card>
+
             <div>
               <h3 className="mb-4">Weekly Actuals</h3>
               

--- a/src/components/KRSpreadsheetView.tsx
+++ b/src/components/KRSpreadsheetView.tsx
@@ -30,9 +30,10 @@ interface KRSpreadsheetViewProps {
   onUpdateKR: (id: string, updates: Partial<KR>) => void;
   onAddComment: (krId: string, comment: Omit<KRComment, 'id' | 'krId' | 'timestamp'>) => void;
   onAddWeeklyActual: (krId: string, weeklyActual: Omit<WeeklyActual, 'id' | 'krId'>) => void;
+  weeks: string[];
 }
 
-export function KRSpreadsheetView({ krs, teams, onUpdateKR, onAddComment, onAddWeeklyActual }: KRSpreadsheetViewProps) {
+export function KRSpreadsheetView({ krs, teams, onUpdateKR, onAddComment, onAddWeeklyActual, weeks }: KRSpreadsheetViewProps) {
   const [editingKR, setEditingKR] = useState<KR | null>(null);
   const [commentingKR, setCommentingKR] = useState<string | null>(null);
   const [newComment, setNewComment] = useState({ content: '', type: 'general' as const, author: 'Current User' });
@@ -408,6 +409,7 @@ export function KRSpreadsheetView({ krs, teams, onUpdateKR, onAddComment, onAddW
         onClose={() => setEditingKR(null)}
         onUpdate={onUpdateKR}
         onAddWeeklyActual={onAddWeeklyActual}
+        weeks={weeks}
       />
     </div>
   );

--- a/src/components/PlanOverridePanel.tsx
+++ b/src/components/PlanOverridePanel.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useAppState } from '../state/store';
+import type { KR } from '../types';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
+import { Switch } from './ui/switch';
+import { Label } from './ui/label';
+import { Input } from './ui/input';
+import { Button } from './ui/button';
+import { Badge } from './ui/badge';
+import { Alert, AlertDescription } from './ui/alert';
+import { cn } from '../lib/utils';
+import { generateWeeks } from '../utils/weeks';
+
+interface PlanOverridePanelProps {
+  kr: Pick<KR, 'id' | 'title' | 'unit' | 'baseline' | 'target'>;
+  weeks?: string[];
+  onDone?: () => void;
+  condensed?: boolean;
+}
+
+interface DraftValue {
+  value: string;
+}
+
+const formatNumber = (value: number | undefined, unit: string): string => {
+  if (value === undefined) {
+    return '—';
+  }
+
+  const formatted = Number.isInteger(value) ? value.toString() : value.toFixed(1);
+  return unit ? `${formatted} ${unit}` : formatted;
+};
+
+export function PlanOverridePanel({ kr, weeks, onDone, condensed }: PlanOverridePanelProps) {
+  const { state, dispatch } = useAppState();
+  const planValues = state.planDraft[kr.id] || {};
+  const actualValues = state.actuals[kr.id] || {};
+
+  const availableWeeks = useMemo(() => {
+    if (weeks && weeks.length > 0) {
+      return weeks;
+    }
+
+    const fromPeriod = state.currentPeriod
+      ? generateWeeks(state.currentPeriod.startISO, state.currentPeriod.endISO)
+      : [];
+
+    if (fromPeriod.length > 0) {
+      return fromPeriod;
+    }
+
+    const unique = new Set<string>();
+    Object.keys(planValues).forEach(week => unique.add(week));
+    Object.keys(actualValues).forEach(week => unique.add(week));
+
+    return Array.from(unique).sort();
+  }, [weeks, state.currentPeriod, planValues, actualValues]);
+
+  const [overrideMode, setOverrideMode] = useState(false);
+  const [draftValues, setDraftValues] = useState<Record<string, DraftValue>>({});
+  const [invalidWeeks, setInvalidWeeks] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!overrideMode) {
+      setDraftValues({});
+      setInvalidWeeks([]);
+      return;
+    }
+
+    setDraftValues(() => {
+      const entries: Record<string, DraftValue> = {};
+      availableWeeks.forEach(week => {
+        const existing = planValues[week];
+        entries[week] = {
+          value: existing !== undefined ? existing.toString() : '',
+        };
+      });
+      return entries;
+    });
+  }, [overrideMode, availableWeeks, planValues]);
+
+  useEffect(() => {
+    if (!overrideMode) {
+      return;
+    }
+
+    const invalid: string[] = [];
+    Object.entries(draftValues).forEach(([week, { value }]) => {
+      if (value.trim() === '') {
+        return;
+      }
+
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        invalid.push(week);
+      }
+    });
+    setInvalidWeeks(invalid);
+  }, [overrideMode, draftValues]);
+
+  const coverage = useMemo(() => {
+    if (availableWeeks.length === 0) {
+      return 0;
+    }
+    const filled = availableWeeks.filter(week => planValues[week] !== undefined).length;
+    return Math.round((filled / availableWeeks.length) * 100);
+  }, [availableWeeks, planValues]);
+
+  const planTotal = useMemo(() => {
+    return availableWeeks.reduce((sum, week) => sum + (planValues[week] ?? 0), 0);
+  }, [availableWeeks, planValues]);
+
+  const actualTotal = useMemo(() => {
+    return availableWeeks.reduce((sum, week) => sum + (actualValues[week] ?? 0), 0);
+  }, [availableWeeks, actualValues]);
+
+  const hasChanges = useMemo(() => {
+    if (!overrideMode) {
+      return false;
+    }
+
+    return availableWeeks.some(week => {
+      const draft = draftValues[week];
+      if (!draft) {
+        return false;
+      }
+
+      const trimmed = draft.value.trim();
+      const existing = planValues[week];
+
+      if (trimmed === '') {
+        return existing !== undefined;
+      }
+
+      const numeric = Number(trimmed);
+      if (!Number.isFinite(numeric)) {
+        return true;
+      }
+
+      return existing !== numeric;
+    });
+  }, [overrideMode, availableWeeks, draftValues, planValues]);
+
+  const handleToggleOverride = (checked: boolean) => {
+    setOverrideMode(checked);
+    if (!checked) {
+      setDraftValues({});
+      setInvalidWeeks([]);
+    }
+  };
+
+  const handleValueChange = (week: string, value: string) => {
+    setDraftValues(prev => ({
+      ...prev,
+      [week]: {
+        value,
+      },
+    }));
+  };
+
+  const handleCancel = () => {
+    setOverrideMode(false);
+    setDraftValues({});
+    setInvalidWeeks([]);
+  };
+
+  const handleSave = () => {
+    if (!overrideMode) {
+      return;
+    }
+
+    availableWeeks.forEach(week => {
+      const draft = draftValues[week];
+      if (!draft) {
+        return;
+      }
+
+      const trimmed = draft.value.trim();
+      if (trimmed === '') {
+        if (planValues[week] !== undefined) {
+          dispatch({ type: 'SET_PLAN_VALUE', krId: kr.id, weekISO: week, value: null });
+        }
+        return;
+      }
+
+      const numeric = Number(trimmed);
+      if (Number.isFinite(numeric)) {
+        dispatch({ type: 'SET_PLAN_VALUE', krId: kr.id, weekISO: week, value: numeric });
+      }
+    });
+
+    setOverrideMode(false);
+    setDraftValues({});
+    setInvalidWeeks([]);
+
+    if (onDone) {
+      onDone();
+    }
+  };
+
+  const containerClasses = cn('space-y-4', condensed && 'p-0');
+
+  return (
+    <div className={containerClasses}>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h4 className="text-base font-medium">Weekly Plan</h4>
+          <p className="text-sm text-muted-foreground">
+            {coverage > 0
+              ? `Hydrated from backend draft with ${coverage}% coverage`
+              : 'No plan values received for this key result yet'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className="text-xs">
+            Plan Σ {planTotal.toLocaleString(undefined, { maximumFractionDigits: 1 })}
+          </Badge>
+          <Badge variant="outline" className="text-xs">
+            Actual Σ {actualTotal.toLocaleString(undefined, { maximumFractionDigits: 1 })}
+          </Badge>
+          <div className="flex items-center gap-2">
+            <Label htmlFor={`override-${kr.id}`} className="text-sm">Override plan</Label>
+            <Switch
+              id={`override-${kr.id}`}
+              checked={overrideMode}
+              onCheckedChange={handleToggleOverride}
+              aria-label="Toggle plan override mode"
+            />
+          </div>
+        </div>
+      </div>
+
+      {invalidWeeks.length > 0 && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            Enter numeric values only. Invalid entries: {invalidWeeks.join(', ')}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-32">Week</TableHead>
+              <TableHead className="w-32">Plan</TableHead>
+              <TableHead className="w-32">Actual</TableHead>
+              <TableHead className="w-32">Variance</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {availableWeeks.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
+                  No weeks available for this key result.
+                </TableCell>
+              </TableRow>
+            ) : (
+              availableWeeks.map(week => {
+                const plan = planValues[week];
+                const actual = actualValues[week];
+                const variance =
+                  plan !== undefined && actual !== undefined ? actual - plan : undefined;
+                const draft = draftValues[week];
+
+                return (
+                  <TableRow key={week}>
+                    <TableCell className="text-sm font-medium">{week}</TableCell>
+                    <TableCell>
+                      {overrideMode ? (
+                        <Input
+                          value={draft?.value ?? ''}
+                          onChange={(event) => handleValueChange(week, event.target.value)}
+                          placeholder="0"
+                          inputMode="decimal"
+                        />
+                      ) : (
+                        <span className="text-sm">
+                          {formatNumber(plan, kr.unit)}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-sm">
+                        {formatNumber(actual, kr.unit)}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={cn(
+                          'text-sm font-medium',
+                          variance === undefined && 'text-muted-foreground',
+                          typeof variance === 'number' && variance > 0 && 'text-green-600',
+                          typeof variance === 'number' && variance < 0 && 'text-red-600',
+                        )}
+                      >
+                        {variance === undefined ? '—' : formatNumber(variance, kr.unit)}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {overrideMode && (
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!hasChanges || invalidWeeks.length > 0}>
+            Save overrides
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a reusable PlanOverridePanel that surfaces backend plan and actual values with override controls
- expose plan overrides through KR cards and spreadsheet detail dialogs while sharing the quarter week cadence
- extend the store with per-cell plan updates and reuse the selected quarter weeks across execution and spreadsheet views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d379c05e0483209e919cdbb5b74914